### PR TITLE
Fixed #1

### DIFF
--- a/asyncio_tools.py
+++ b/asyncio_tools.py
@@ -45,30 +45,23 @@ class CompoundException(Exception):
 class GatheredResults:
 
     # __dict__ is required for cached_property
-    __slots__ = ("results", "__dict__")
+    __slots__ = ("__results", "__dict__")
 
     def __init__(self, results: t.List[t.Any]):
-        self.results = results
+        self.__results = results
 
     ###########################################################################
 
-    def __setattr__(self, key, value):
-        """
-        Since we use cached_properties for most of the lookups, we don't want
-        the underlying results to be changed. There should be no reason for a
-        user to want to change the results, but just to be sure we raise a
-        ValueError.
-        """
-        if key == "results":
-            raise ValueError("results is immutable")
-        super().__setattr__(key, value)
+    @property
+    def results(self):
+        return self.__results
 
     @property
     def all(self) -> t.List[t.Any]:
         """
         Just a proxy.
         """
-        return self.results
+        return self.__results
 
     ###########################################################################
 

--- a/tests/test_gathered_results.py
+++ b/tests/test_gathered_results.py
@@ -36,5 +36,12 @@ class TestGatheredResults(TestCase):
 
     def test_set(self):
         results = GatheredResults([])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             results.results = None
+
+    def test_set_2(self):
+        results = asyncio.run(gather(good(), bad()))
+        with self.assertRaises(AttributeError):
+            results.results = None
+        self.assertEqual(len(results.all), 2)
+        self.assertEqual(len(results.results), 2)


### PR DESCRIPTION
Here is approach of mine to fix the the issue:

* store results into private attribute `__results`
* add attribute getter for `results`
* all remaining code will use `results`